### PR TITLE
Support platform type "all"

### DIFF
--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -14,7 +14,7 @@ OPTIONS:
     -l, --list                   List all commands in the cache
     -f, --render <FILE>          Render a specific markdown file
     -p, --platform <PLATFORM>    Override the operating system [possible values: linux, macos,
-                                 windows, sunos, osx]
+                                 windows, sunos, all]
     -o, --os <OS>                Deprecated alias of `platform`
     -L, --language <LANGUAGE>    Override the language
     -u, --update                 Update the local cache

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,7 +16,7 @@ use zip::ZipArchive;
 
 use crate::{
     error::TealdeerError::{self, CacheError, UpdateError},
-    types::{PathSource, PlatformType},
+    types::{PathSource, PlatformStrategy, PlatformType},
 };
 
 static CACHE_DIR_ENV_VAR: &str = "TEALDEER_CACHE_DIR";
@@ -27,7 +27,7 @@ static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
 #[derive(Debug)]
 pub struct Cache {
     url: String,
-    platform: PlatformType,
+    platform: PlatformStrategy,
 }
 
 #[derive(Debug)]
@@ -64,7 +64,7 @@ pub enum CacheFreshness {
 }
 
 impl Cache {
-    pub fn new<S>(url: S, platform: PlatformType) -> Self
+    pub fn new<S>(url: S, platform: PlatformStrategy) -> Self
     where
         S: Into<String>,
     {
@@ -196,7 +196,7 @@ impl Cache {
 
     /// Return the platform directory.
     fn get_platform_dir(&self) -> &'static str {
-        match self.platform {
+        match self.platform.platform_type {
             PlatformType::Linux { .. } => "linux",
             PlatformType::OsX { .. } => "osx",
             PlatformType::SunOs { .. } => "sunos",
@@ -305,7 +305,7 @@ impl Cache {
         let mut pages = WalkDir::new(platforms_dir)
             .min_depth(1) // Skip root directory
             .into_iter()
-            .filter_entry(|e| self.platform.is_all() || should_walk(e)) // Filter out pages for other architectures
+            .filter_entry(|e| self.platform.list_all || should_walk(e)) // Filter out pages for other architectures
             .filter_map(Result::ok) // Convert results to options, filter out errors
             .filter_map(|e| {
                 let path = e.path();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -197,10 +197,10 @@ impl Cache {
     /// Return the platform directory.
     fn get_platform_dir(&self) -> &'static str {
         match self.platform {
-            PlatformType::Linux => "linux",
-            PlatformType::OsX => "osx",
-            PlatformType::SunOs => "sunos",
-            PlatformType::Windows => "windows",
+            PlatformType::Linux { .. } => "linux",
+            PlatformType::OsX { .. } => "osx",
+            PlatformType::SunOs { .. } => "sunos",
+            PlatformType::Windows { .. } => "windows",
         }
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -305,7 +305,7 @@ impl Cache {
         let mut pages = WalkDir::new(platforms_dir)
             .min_depth(1) // Skip root directory
             .into_iter()
-            .filter_entry(|e| should_walk(e)) // Filter out pages for other architectures
+            .filter_entry(|e| self.platform.is_all() || should_walk(e)) // Filter out pages for other architectures
             .filter_map(Result::ok) // Convert results to options, filter out errors
             .filter_map(|e| {
                 let path = e.path();

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ use crate::{
     error::TealdeerError::ConfigError,
     extensions::Dedup,
     output::print_page,
-    types::{ColorOptions, PlatformType},
+    types::{ColorOptions, PlatformStrategy, PlatformType},
     utils::{print_error, print_warning},
 };
 
@@ -89,7 +89,7 @@ struct Args {
         hide_possible_values = true,
         hide_default_value = true,
     )]
-    platform: PlatformType,
+    platform: PlatformStrategy,
 
     /// Deprecated alias of `platform`
     #[clap(
@@ -101,7 +101,7 @@ struct Args {
         hide_possible_values = true,
         hide_default_value = true,
     )]
-    os: PlatformType,
+    os: PlatformStrategy,
 
     /// Override the language
     #[clap(short = 'L', long = "language")]
@@ -406,8 +406,8 @@ fn main() {
             "The -m / --markdown flag is deprecated, use -r / --raw instead",
         );
     }
-    let default_platform = PlatformType::current(false);
-    if args.os != default_platform {
+    let default_platform = PlatformType::current();
+    if args.os.platform_type != default_platform || args.os.list_all {
         print_warning(
             enable_styles,
             "The -o / --os flag is deprecated, use -p / --platform instead",

--- a/src/types.rs
+++ b/src/types.rs
@@ -78,6 +78,19 @@ impl PlatformType {
     pub fn current(all: bool) -> Self {
         Self::Other { all }
     }
+
+    /// Return whether or not the `all` flag is set.
+    ///
+    /// This flag is only relevant when listing pages: When `all` is set to
+    /// `true`, then the pages for all platforms should be listed.
+    pub fn is_all(self) -> bool {
+        match self {
+            Self::Linux { all }
+            | Self::OsX { all }
+            | Self::SunOs { all }
+            | Self::Windows { all } => all,
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,19 +8,19 @@ use serde_derive::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 #[allow(dead_code)]
 pub enum PlatformType {
-    Linux,
-    OsX,
-    SunOs,
-    Windows,
+    Linux { all: bool },
+    OsX { all: bool },
+    SunOs { all: bool },
+    Windows { all: bool },
 }
 
 impl fmt::Display for PlatformType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Linux => write!(f, "Linux"),
-            Self::OsX => write!(f, "macOS / BSD"),
-            Self::SunOs => write!(f, "SunOS"),
-            Self::Windows => write!(f, "Windows"),
+            Self::Linux { .. } => write!(f, "Linux"),
+            Self::OsX { .. } => write!(f, "macOS / BSD"),
+            Self::SunOs { .. } => write!(f, "SunOS"),
+            Self::Windows { .. } => write!(f, "Windows"),
         }
     }
 }
@@ -30,12 +30,14 @@ impl str::FromStr for PlatformType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "linux" => Ok(Self::Linux),
-            "osx" | "macos" => Ok(Self::OsX),
-            "sunos" => Ok(Self::SunOs),
-            "windows" => Ok(Self::Windows),
+            "linux" => Ok(Self::Linux { all: false }),
+            "osx" | "macos" => Ok(Self::OsX { all: false }),
+            "windows" => Ok(Self::Windows { all: false }),
+            "sunos" => Ok(Self::SunOs { all: false }),
+            "current" => Ok(PlatformType::current(false)),
+            "all" => Ok(PlatformType::current(true)),
             other => Err(format!(
-                "Unknown OS: {}. Possible values: linux, macos, osx, sunos, windows",
+                "Unknown platform: {}. Possible values: linux, macos, osx, windows, sunos, current, all",
                 other
             )),
         }
@@ -44,8 +46,8 @@ impl str::FromStr for PlatformType {
 
 impl PlatformType {
     #[cfg(target_os = "linux")]
-    pub fn current() -> Self {
-        Self::Linux
+    pub fn current(all: bool) -> Self {
+        Self::Linux { all }
     }
 
     #[cfg(any(
@@ -55,13 +57,13 @@ impl PlatformType {
         target_os = "openbsd",
         target_os = "dragonfly"
     ))]
-    pub fn current() -> Self {
-        Self::OsX
+    pub fn current(all: bool) -> Self {
+        Self::OsX { all }
     }
 
     #[cfg(target_os = "windows")]
-    pub fn current() -> Self {
-        Self::Windows
+    pub fn current(all: bool) -> Self {
+        Self::Windows { all }
     }
 
     #[cfg(not(any(
@@ -73,8 +75,8 @@ impl PlatformType {
         target_os = "dragonfly",
         target_os = "windows"
     )))]
-    pub fn current() -> Self {
-        Self::Other
+    pub fn current(all: bool) -> Self {
+        Self::Other { all }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,40 +2,79 @@
 
 use std::{fmt, str};
 
-use serde_derive::{Deserialize, Serialize};
+use serde::Deserialize;
 
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// The platform types supported by tldr.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[allow(dead_code)]
 pub enum PlatformType {
-    Linux { all: bool },
-    OsX { all: bool },
-    SunOs { all: bool },
-    Windows { all: bool },
+    Linux,
+    OsX,
+    SunOs,
+    Windows,
 }
 
 impl fmt::Display for PlatformType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Linux { .. } => write!(f, "Linux"),
-            Self::OsX { .. } => write!(f, "macOS / BSD"),
-            Self::SunOs { .. } => write!(f, "SunOS"),
-            Self::Windows { .. } => write!(f, "Windows"),
+            Self::Linux => write!(f, "Linux"),
+            Self::OsX => write!(f, "macOS / BSD"),
+            Self::SunOs => write!(f, "SunOS"),
+            Self::Windows => write!(f, "Windows"),
         }
     }
 }
 
-impl str::FromStr for PlatformType {
+/// The platform lookup strategy.
+///
+/// Includes both the platform type, as well as
+#[derive(Debug, Copy, Clone)]
+pub struct PlatformStrategy {
+    /// The platform type that should be looked up.
+    pub platform_type: PlatformType,
+    /// Flag indicating whether all pages should be listed or not. This is only
+    /// used when the special platform type `all` is specified by the user.
+    pub list_all: bool,
+}
+
+impl PlatformStrategy {
+    pub fn new(platform_type: PlatformType) -> Self {
+        Self {
+            platform_type,
+            list_all: false,
+        }
+    }
+
+    /// Return a `PlatformStrategy` containing the current platform as the
+    /// target platform type.
+    pub fn current() -> Self {
+        Self {
+            platform_type: PlatformType::current(),
+            list_all: false,
+        }
+    }
+
+    /// Like `current()`, but when listing the pages, return the pages for all
+    /// platforms, not just for the current platform.
+    pub fn all() -> Self {
+        Self {
+            platform_type: PlatformType::current(),
+            list_all: true,
+        }
+    }
+}
+
+impl str::FromStr for PlatformStrategy {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "linux" => Ok(Self::Linux { all: false }),
-            "osx" | "macos" => Ok(Self::OsX { all: false }),
-            "windows" => Ok(Self::Windows { all: false }),
-            "sunos" => Ok(Self::SunOs { all: false }),
-            "current" => Ok(PlatformType::current(false)),
-            "all" => Ok(PlatformType::current(true)),
+            "linux" => Ok(PlatformStrategy::new(PlatformType::Linux)),
+            "osx" | "macos" => Ok(PlatformStrategy::new(PlatformType::OsX)),
+            "windows" => Ok(PlatformStrategy::new(PlatformType::Windows)),
+            "sunos" => Ok(PlatformStrategy::new(PlatformType::SunOs)),
+            "current" => Ok(PlatformStrategy::current()),
+            "all" => Ok(PlatformStrategy::all()),
             other => Err(format!(
                 "Unknown platform: {}. Possible values: linux, macos, osx, windows, sunos, current, all",
                 other
@@ -46,8 +85,8 @@ impl str::FromStr for PlatformType {
 
 impl PlatformType {
     #[cfg(target_os = "linux")]
-    pub fn current(all: bool) -> Self {
-        Self::Linux { all }
+    pub fn current() -> Self {
+        Self::Linux
     }
 
     #[cfg(any(
@@ -57,13 +96,13 @@ impl PlatformType {
         target_os = "openbsd",
         target_os = "dragonfly"
     ))]
-    pub fn current(all: bool) -> Self {
-        Self::OsX { all }
+    pub fn current() -> Self {
+        Self::OsX
     }
 
     #[cfg(target_os = "windows")]
-    pub fn current(all: bool) -> Self {
-        Self::Windows { all }
+    pub fn current() -> Self {
+        Self::Windows
     }
 
     #[cfg(not(any(
@@ -75,21 +114,8 @@ impl PlatformType {
         target_os = "dragonfly",
         target_os = "windows"
     )))]
-    pub fn current(all: bool) -> Self {
-        Self::Other { all }
-    }
-
-    /// Return whether or not the `all` flag is set.
-    ///
-    /// This flag is only relevant when listing pages: When `all` is set to
-    /// `true`, then the pages for all platforms should be listed.
-    pub fn is_all(self) -> bool {
-        match self {
-            Self::Linux { all }
-            | Self::OsX { all }
-            | Self::SunOs { all }
-            | Self::Windows { all } => all,
-        }
+    pub fn current() -> Self {
+        Self::Other
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -524,6 +524,40 @@ fn test_list_flag_rendering() {
 }
 
 #[test]
+fn test_list_platform_filtering() {
+    let testenv = TestEnv::new();
+
+    testenv.add_os_entry("common", "a-common", "");
+    testenv.add_os_entry("windows", "a-windows", "");
+    testenv.add_os_entry("linux", "a-linux", "");
+    testenv.add_os_entry("linux", "b-linux", "");
+
+    // Filter: linux
+    testenv
+        .command()
+        .args(["--list", "--platform", "linux"])
+        .assert()
+        .success()
+        .stdout("a-common\na-linux\nb-linux\n");
+
+    // Filter: windows
+    testenv
+        .command()
+        .args(["--list", "--platform", "windows"])
+        .assert()
+        .success()
+        .stdout("a-common\na-windows\n");
+
+    // Filter: all
+    testenv
+        .command()
+        .args(["--list", "--platform", "all"])
+        .assert()
+        .success()
+        .stdout("a-common\na-linux\na-windows\nb-linux\n");
+}
+
+#[test]
 fn test_autoupdate_cache() {
     let testenv = TestEnv::new();
 


### PR DESCRIPTION
This is the third part of #209.

The goal is supporting the special `all` platform that results in pages
for all platforms being listed when calling `--list`. It's part of the
tldr client specification.

However, `All` should not be a variant of the `PlatformType` enum,
because `Current` isn't a `PlatformType` either. Thus, we accept the
string `all` but convert it into the current platform when parsing.

For consistency, the same is done when no platform is specified, by
introducing yet another possible value `current` which is used by
default. This way, we get rid of the `Option`.

Due to limitations in clap, we had to remove the `requires = "command"`
requirement, however that's actually a good thing because `--list` does
not require a command either, but supports the `--platform` parameter.

To simplify handling of os / platform arguments, a conflict between
`--platform` and `--os` was introduced.