### PR TITLE
Replace `atty` with `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,17 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,15 +539,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -814,7 +794,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1452,7 +1432,6 @@ dependencies = [
  "anyhow",
  "app_dirs2",
  "assert_cmd",
- "atty",
  "clap",
  "env_logger",
  "escargot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 app_dirs = { version = "2", package = "app_dirs2" }
-atty = "0.2"
 clap = { version = "4", features = ["std", "derive", "help", "usage", "cargo", "error-context", "color", "wrap_help"], default-features = false }
 env_logger = { version = "0.11", optional = true }
 log = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,13 @@ compile_error!(
     "exactly one of the features \"native-roots\", \"webpki-roots\" or \"native-tls\" must be enabled"
 );
 
-use std::{env, process};
+use std::{
+    env,
+    io::{self, IsTerminal},
+    process,
+};
 
 use app_dirs::AppInfo;
-use atty::Stream;
 use clap::Parser;
 
 mod cache;
@@ -258,7 +261,7 @@ fn main() {
         // * NO_COLOR env var isn't set: https://no-color.org/
         // * The output stream is stdout (not being piped)
         ColorOptions::Auto => {
-            ansi_support && env::var_os("NO_COLOR").is_none() && atty::is(Stream::Stdout)
+            ansi_support && env::var_os("NO_COLOR").is_none() && io::stdout().is_terminal()
         }
         // Disable styling
         ColorOptions::Never => false,


### PR DESCRIPTION
The `atty` crate is unmaintained, `std::io::IsTerminal` is stable since Rust 1.70.
