### PR TITLE
Add `--no-pager` flag

### DIFF
--- a/completion/bash_tealdeer
+++ b/completion/bash_tealdeer
@@ -6,7 +6,7 @@ _tealdeer()
 	_init_completion || return
 
 	case $prev in
-		-h|--help|-v|--version|-l|--list|-u|--update|--no-auto-update|-c|--clear-cache|--pager|-r|--raw|--show-paths|--seed-config|-q|--quiet)
+		-h|--help|-v|--version|-l|--list|-u|--update|--no-auto-update|-c|--clear-cache|--pager|--no-pager|-r|--raw|--show-paths|--seed-config|-q|--quiet)
 			return
 			;;
 		-f|--render)

--- a/completion/fish_tealdeer
+++ b/completion/fish_tealdeer
@@ -13,6 +13,7 @@ complete -c tldr -s u -l update         -d 'Update the local cache.' -f
 complete -c tldr      -l no-auto-update -d 'If auto update is configured, disable it for this run.' -f
 complete -c tldr -s c -l clear-cache    -d 'Clear the local cache.' -f
 complete -c tldr      -l pager          -d 'Use a pager to page output.' -f
+complete -c tldr      -l no-pager       -d 'Do not use a pager to page output, overrides --pager and config.' -f
 complete -c tldr -s r -l raw            -d 'Display the raw markdown instead of rendering it.' -f
 complete -c tldr -s q -l quiet          -d 'Suppress informational messages.' -f
 complete -c tldr      -l show-paths     -d 'Show file and directory paths used by tealdeer.' -f

--- a/completion/zsh_tealdeer
+++ b/completion/zsh_tealdeer
@@ -30,6 +30,7 @@ _tealdeer() {
         "($I)--no-auto-update[If auto update is configured, disable it for this run]"
         "($I -c --clear-cache)"{-c,--clear-cache}"[Clear the local cache]"
         "($I)--pager[Use a pager to page output]"
+        "($I)--no-pager[Do not use a pager to page output, overrides --pager and config]"
         "($I -r --raw)"{-r,--raw}"[Display the raw markdown instead of rendering it]"
         "($I -q --quiet)"{-q,--quiet}"[Suppress informational messages]"
         "($I)--show-paths[Show file and directory paths used by tealdeer]"

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -17,6 +17,7 @@ Options:
       --no-auto-update       If auto update is configured, disable it for this run
   -c, --clear-cache          Clear the local cache
       --pager                Use a pager to page output
+      --no-pager             Do not use a pager to page output, overrides `--pager` and config
   -r, --raw                  Display the raw markdown instead of rendering it
   -q, --quiet                Suppress informational messages
       --show-paths           Show file and directory paths used by tealdeer

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,10 @@ pub(crate) struct Cli {
     #[arg(long = "pager", requires = "command_or_file")]
     pub pager: bool,
 
+    /// Do not use a pager to page output, overrides `--pager` and config
+    #[arg(long = "no-pager")]
+    pub no_pager: bool,
+
     /// Display the raw markdown instead of rendering it
     #[arg(short = 'r', long = "raw", requires = "command_or_file")]
     pub raw: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,7 @@ fn main() {
     // If a local file was passed in, render it and exit
     if let Some(file) = args.render {
         let path = PageLookupResult::with_page(file);
-        if let Err(ref e) = print_page(&path, args.raw, enable_styles, args.pager, &config) {
+        if let Err(ref e) = print_page(&path, args.raw, enable_styles, args.pager, args.no_pager, &config) {
             print_error(enable_styles, e);
             process::exit(1);
         } else {
@@ -361,7 +361,7 @@ fn main() {
             platforms,
         ) {
             if let Err(ref e) =
-                print_page(&lookup_result, args.raw, enable_styles, args.pager, &config)
+                print_page(&lookup_result, args.raw, enable_styles, args.pager, args.no_pager, &config)
             {
                 print_error(enable_styles, e);
                 process::exit(1);

--- a/src/output.rs
+++ b/src/output.rs
@@ -34,13 +34,14 @@ pub fn print_page(
     enable_markdown: bool,
     enable_styles: bool,
     use_pager: bool,
+    not_use_pager: bool,
     config: &Config,
 ) -> Result<()> {
     // Create reader from file(s)
     let reader = lookup_result.reader()?;
 
     // Configure pager if applicable
-    if use_pager || config.display.use_pager {
+    if (use_pager || config.display.use_pager) && !not_use_pager {
         configure_pager(enable_styles);
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -560,6 +560,18 @@ fn test_pager_flag_enable() {
         .args(["--pager", "which"])
         .assert()
         .success();
+
+    testenv
+        .command()
+        .args(["--no-pager", "which"])
+        .assert()
+        .success();
+
+    testenv
+        .command()
+        .args(["--pager", "--no-pager", "which"])
+        .assert()
+        .success();
 }
 
 #[test]
@@ -908,6 +920,13 @@ fn test_pager_warning() {
         .assert()
         .success()
         .stderr(contains("pager flag not available on Windows"));
+
+    // no-pager flag should not cause issues
+    testenv
+        .command()
+        .args(["--no-pager", "which"])
+        .assert()
+        .success()
 }
 
 /// Ensure that page lookup is case insensitive, so a page lookup for `eyed3`


### PR DESCRIPTION
In my `tealdeer` config I have `use_pager` set to `true`, but if there's a case I want it not to be paged, there is no easy way to do this. The only way I found is to change the `use_pager` option in the config to `false`.
So I decided it would be nice to have a `--no-pager` flag that disables paging whether it's enabled in the config or by the `--pager` flag.
I also added some tests and edited the shell completion scripts, I hope I made everything right.