### PR TITLE
Placeholder escaping

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6,16 +6,31 @@ use crate::{extensions::FindFrom, types::LineType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Represents a snippet from a page of a specific highlighting class.
-pub enum PageSnippet<'a> {
-    CommandName(&'a str),
-    Variable(&'a str),
-    NormalCode(&'a str),
-    Description(&'a str),
-    Text(&'a str),
+pub enum PageSnippet<T> {
+    CommandName(T),
+    Variable(T),
+    NormalCode(T),
+    Description(T),
+    Text(T),
     Linebreak,
 }
 
-impl PageSnippet<'_> {
+impl<T> PageSnippet<T> {
+    pub fn map<F, U>(self, f: F) -> PageSnippet<U>
+    where
+        F: Fn(T) -> U,
+    {
+        todo!()
+    }
+}
+
+impl PartialEq<PageSnippet<&str>> for PageSnippet<String> {
+    fn eq(&self, other: &PageSnippet<&str>) -> bool {
+        todo!()
+    }
+}
+
+impl PageSnippet<&str> {
     pub fn is_empty(&self) -> bool {
         use PageSnippet::*;
 
@@ -34,7 +49,7 @@ pub fn highlight_lines<L, F, E>(
 ) -> Result<(), E>
 where
     L: Iterator<Item = LineType>,
-    F: for<'snip> FnMut(PageSnippet<'snip>) -> Result<(), E>,
+    F: for<'snip> FnMut(PageSnippet<&'snip str>) -> Result<(), E>,
 {
     let mut command = String::new();
     for line in lines {
@@ -71,7 +86,7 @@ where
 fn highlight_code<'a, E>(
     command: &'a str,
     text: &'a str,
-    process_snippet: &mut impl FnMut(PageSnippet<'a>) -> Result<(), E>,
+    process_snippet: &mut impl FnMut(PageSnippet<&str>) -> Result<(), E>,
 ) -> Result<(), E> {
     let variable_splits = text
         .split("}}")
@@ -89,7 +104,7 @@ fn highlight_code<'a, E>(
 fn highlight_code_segment<'a, E>(
     command_name: &'a str,
     mut segment: &'a str,
-    process_snippet: &mut impl FnMut(PageSnippet<'a>) -> Result<(), E>,
+    process_snippet: &mut impl FnMut(PageSnippet<&'a str>) -> Result<(), E>,
 ) -> Result<(), E> {
     if !command_name.is_empty() {
         let mut search_start = 0;
@@ -162,11 +177,11 @@ mod tests {
         use super::*;
         use PageSnippet::*;
 
-        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<'a>> {
+        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<String>> {
             let mut yielded = Vec::new();
-            let mut process_snippet = |snip: PageSnippet<'a>| {
+            let mut process_snippet = |snip: PageSnippet<_>| {
                 if !snip.is_empty() {
-                    yielded.push(snip);
+                    yielded.push(snip.map(str::to_string));
                 }
                 Ok::<(), ()>(())
             };
@@ -244,16 +259,16 @@ mod tests {
         use super::*;
         use PageSnippet::*;
 
-        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<'a>> {
+        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<String>> {
             let mut yielded = Vec::new();
-            let mut process_snippet = |snip: PageSnippet<'a>| {
+            let mut process_snippet = |snip: PageSnippet<&str>| {
                 if !snip.is_empty() {
-                    yielded.push(snip);
+                    yielded.push(snip.map(str::to_string));
                 }
                 Ok::<(), ()>(())
             };
 
-            highlight_code(cmd, segment, &mut process_snippet)
+            highlight_code(cmd, segment.to_string(), &mut process_snippet)
                 .expect("highlight code segment failed");
             yielded
         }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -132,7 +132,6 @@ fn is_freestanding_substring(surrounding: &str, substring: (usize, usize)) -> bo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use PageSnippet::*;
 
     #[test]
     fn test_is_freestanding_substring() {
@@ -159,80 +158,170 @@ mod tests {
         ));
     }
 
-    fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<'a>> {
-        let mut yielded = Vec::new();
-        let mut process_snippet = |snip: PageSnippet<'a>| {
-            if !snip.is_empty() {
-                yielded.push(snip);
-            }
-            Ok::<(), ()>(())
-        };
+    mod highlight_code_segment {
+        use super::*;
+        use PageSnippet::*;
 
-        highlight_code_segment(cmd, segment, &mut process_snippet)
-            .expect("highlight code segment failed");
-        yielded
+        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<'a>> {
+            let mut yielded = Vec::new();
+            let mut process_snippet = |snip: PageSnippet<'a>| {
+                if !snip.is_empty() {
+                    yielded.push(snip);
+                }
+                Ok::<(), ()>(())
+            };
+
+            highlight_code_segment(cmd, segment, &mut process_snippet)
+                .expect("highlight code segment failed");
+            yielded
+        }
+
+        #[test]
+        fn test_highlight_code_segment() {
+            assert!(run("make", "").is_empty());
+            assert_eq!(
+                &run("make", "make all CC=clang -q"),
+                &[CommandName("make"), NormalCode(" all CC=clang -q")]
+            );
+            assert_eq!(
+                &run("make", "  make money --always-make"),
+                &[
+                    NormalCode("  "),
+                    CommandName("make"),
+                    NormalCode(" money --always-make")
+                ]
+            );
+            assert_eq!(
+                &run("git commit", "git commit -m 'git commit'"),
+                &[CommandName("git commit"), NormalCode(" -m 'git commit'"),]
+            );
+        }
+
+        #[test]
+        fn test_i18n() {
+            assert_eq!(
+                &run("mäke", "mäke höhlenrätselbücher"),
+                &[CommandName("mäke"), NormalCode(" höhlenrätselbücher")]
+            );
+            assert_eq!(
+                &run(
+                    "Müll",
+                    "1000 Gründe warum Müll heute größer ist als Müll früher, ärgerlich"
+                ),
+                &[
+                    NormalCode("1000 Gründe warum "),
+                    CommandName("Müll"),
+                    NormalCode(" heute größer ist als "),
+                    CommandName("Müll"),
+                    NormalCode(" früher, ärgerlich")
+                ]
+            );
+            assert_eq!(
+                &run(
+                    "übergang",
+                    "die Zustandsübergangsfunktion übergang Änderungen",
+                ),
+                &[
+                    NormalCode("die Zustandsübergangsfunktion "),
+                    CommandName("übergang"),
+                    NormalCode(" Änderungen")
+                ],
+            );
+        }
+
+        #[test]
+        fn test_empty_command() {
+            let segment = "some code";
+            let snippets = [NormalCode(segment)];
+
+            assert_eq!(run("", segment), snippets);
+            assert_eq!(run(" ", segment), snippets);
+            assert_eq!(run("  \t ", segment), snippets);
+        }
     }
 
-    #[test]
-    fn test_highlight_code_segment() {
-        assert!(run("make", "").is_empty());
-        assert_eq!(
-            &run("make", "make all CC=clang -q"),
-            &[CommandName("make"), NormalCode(" all CC=clang -q")]
-        );
-        assert_eq!(
-            &run("make", "  make money --always-make"),
-            &[
-                NormalCode("  "),
-                CommandName("make"),
-                NormalCode(" money --always-make")
-            ]
-        );
-        assert_eq!(
-            &run("git commit", "git commit -m 'git commit'"),
-            &[CommandName("git commit"), NormalCode(" -m 'git commit'"),]
-        );
-    }
+    mod placeholders {
+        use super::*;
+        use PageSnippet::*;
 
-    #[test]
-    fn test_i18n() {
-        assert_eq!(
-            &run("mäke", "mäke höhlenrätselbücher"),
-            &[CommandName("mäke"), NormalCode(" höhlenrätselbücher")]
-        );
-        assert_eq!(
-            &run(
-                "Müll",
-                "1000 Gründe warum Müll heute größer ist als Müll früher, ärgerlich"
-            ),
-            &[
-                NormalCode("1000 Gründe warum "),
-                CommandName("Müll"),
-                NormalCode(" heute größer ist als "),
-                CommandName("Müll"),
-                NormalCode(" früher, ärgerlich")
-            ]
-        );
-        assert_eq!(
-            &run(
-                "übergang",
-                "die Zustandsübergangsfunktion übergang Änderungen",
-            ),
-            &[
-                NormalCode("die Zustandsübergangsfunktion "),
-                CommandName("übergang"),
-                NormalCode(" Änderungen")
-            ],
-        );
-    }
+        fn run<'a>(cmd: &'a str, segment: &'a str) -> Vec<PageSnippet<'a>> {
+            let mut yielded = Vec::new();
+            let mut process_snippet = |snip: PageSnippet<'a>| {
+                if !snip.is_empty() {
+                    yielded.push(snip);
+                }
+                Ok::<(), ()>(())
+            };
 
-    #[test]
-    fn test_empty_command() {
-        let segment = "some code";
-        let snippets = [NormalCode(segment)];
+            highlight_code(cmd, segment, &mut process_snippet)
+                .expect("highlight code segment failed");
+            yielded
+        }
 
-        assert_eq!(run("", segment), snippets);
-        assert_eq!(run(" ", segment), snippets);
-        assert_eq!(run("  \t ", segment), snippets);
+        #[test]
+        fn variable_vs_escaped() {
+            assert_eq!(
+                run("ping", "ping {{example.com}}"),
+                [
+                    CommandName("ping"),
+                    NormalCode(" "),
+                    Variable("example.com"),
+                ],
+            );
+            assert_eq!(
+                run(
+                    "docker inspect",
+                    r"docker inspect --format '\{\{range.NetworkSettings.Networks\}\}\{\{.IPAddress\}\}\{\{end\}\}' {{container}}"
+                ),
+                [
+                    CommandName("docker inspect"),
+                    NormalCode(
+                        " --format '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "
+                    ),
+                    Variable("container"),
+                ],
+            );
+            assert_eq!(
+                run("mount", r"mount \\{{computer_name}}\{{share_name}} Z:"),
+                [
+                    CommandName("mount"),
+                    NormalCode(r" \\"),
+                    Variable("computer_name"),
+                    NormalCode(r"\"),
+                    Variable("share_name"),
+                    NormalCode(" Z:"),
+                ],
+            );
+
+            assert_eq!(run("", r"\{"), [NormalCode(r"\{")]);
+            assert_eq!(run("", r"\{{a"), [NormalCode(r"\{{a")]);
+            assert_eq!(run("", r"\{{a}}"), [NormalCode(r"\"), Variable("a")]);
+
+            // Placeholder has begin marker, but no end marker
+            assert_eq!(run("", r"{{\}\}}"), [NormalCode("{{}}}")]);
+        }
+
+        #[test]
+        fn outer_precedence() {
+            assert_eq!(
+                run("git stash", "git stash show --patch {{stash@{0}}}"),
+                [
+                    CommandName("git stash"),
+                    NormalCode(" show --patch "),
+                    Variable("stash@{0}"),
+                ],
+            );
+
+            // The following is not listed in the specification, but this is the highlighting I would expect.
+            assert_eq!(
+                run("rg", "rg {{}}}"),
+                [CommandName("rg"), NormalCode(" "), Variable("}")]
+            );
+
+            // And these are just to document the current behavior
+            assert_eq!(run("", "{{{}}}"), [Variable("{}")]);
+            assert_eq!(run("", "{{{{}}}"), [Variable("{{}")]);
+            assert_eq!(run("", "{{{}}}}"), [Variable("{}}")]);
+        }
     }
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -20,13 +20,28 @@ impl<T> PageSnippet<T> {
     where
         F: Fn(T) -> U,
     {
-        todo!()
+        match self {
+            PageSnippet::CommandName(s) => PageSnippet::CommandName(f(s)),
+            PageSnippet::Variable(s) => PageSnippet::Variable(f(s)),
+            PageSnippet::NormalCode(s) => PageSnippet::NormalCode(f(s)),
+            PageSnippet::Description(s) => PageSnippet::Description(f(s)),
+            PageSnippet::Text(s) => PageSnippet::Text(f(s)),
+            PageSnippet::Linebreak => PageSnippet::Linebreak,
+        }
     }
 }
 
 impl PartialEq<PageSnippet<&str>> for PageSnippet<String> {
     fn eq(&self, other: &PageSnippet<&str>) -> bool {
-        todo!()
+        match (self, other) {
+            (PageSnippet::CommandName(s), PageSnippet::CommandName(t)) => s == t,
+            (PageSnippet::Variable(s), PageSnippet::Variable(t)) => s == t,
+            (PageSnippet::NormalCode(s), PageSnippet::NormalCode(t)) => s == t,
+            (PageSnippet::Description(s), PageSnippet::Description(t)) => s == t,
+            (PageSnippet::Text(s), PageSnippet::Text(t)) => s == t,
+            (PageSnippet::Linebreak, PageSnippet::Linebreak) => true,
+            _ => false,
+        }
     }
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -86,7 +86,7 @@ where
             LineType::ExampleText(text) => process_snippet(PageSnippet::Text(&text))?,
             LineType::ExampleCode(text) => {
                 process_snippet(PageSnippet::NormalCode("      "))?;
-                highlight_code(&command, &text, process_snippet)?;
+                highlight_code(&command, text, process_snippet)?;
                 process_snippet(PageSnippet::Linebreak)?;
             }
 
@@ -98,18 +98,70 @@ where
 }
 
 /// Highlight code examples including user variables in {{ curly braces }}.
-fn highlight_code<'a, E>(
-    command: &'a str,
-    text: &'a str,
+fn highlight_code<E>(
+    command: &str,
+    mut text: String,
     process_snippet: &mut impl FnMut(PageSnippet<&str>) -> Result<(), E>,
 ) -> Result<(), E> {
-    let variable_splits = text
-        .split("}}")
-        .map(|s| s.split_once("{{").unwrap_or((s, "")));
-    for (code_segment, variable) in variable_splits {
-        highlight_code_segment(command, code_segment, process_snippet)?;
-        process_snippet(PageSnippet::Variable(variable))?;
+    fn find_marker(s: &str, marker: &str, forbidden_prefix: &str) -> Option<usize> {
+        assert_eq!(
+            marker.as_bytes()[0],
+            forbidden_prefix.as_bytes()[forbidden_prefix.len() - 1]
+        );
+
+        let mut search_start = 0;
+        while search_start < s.len() {
+            let Some(marker_index) = s.find_from(marker, search_start) else {
+                return None;
+            };
+
+            // Avoid matching the "{{" at the end of "\{\{{"
+            let prefix_start = marker_index as isize - forbidden_prefix.len() as isize + 1;
+            let overlaps_with_prefix =
+                0 <= prefix_start && &s[prefix_start as usize..=marker_index] == forbidden_prefix;
+            if !overlaps_with_prefix {
+                return Some(marker_index);
+            }
+
+            // The next valid marker cannot include the first character of the current match
+            search_start = marker_index + 1;
+        }
+
+        None
     }
+
+    // NOTE: This is not optimal, as it allocates one String for each `replace`
+    let replace_escaped = |s: &str| s.replace(r"\{\{", "{{").replace(r"\}\}", "}}");
+
+    while !text.is_empty() {
+        let Some(placeholder_start) = find_marker(&text, "{{", r"\{\{") else {
+            return highlight_code_segment(command, &replace_escaped(&text), process_snippet);
+        };
+        let Some(mut placeholder_end) = find_marker(&text[placeholder_start + 2..], "}}", r"\}\}")
+        else {
+            return highlight_code_segment(command, &replace_escaped(&text), process_snippet);
+        };
+        placeholder_end += placeholder_start + 2;
+
+        // Greedily extend matched range
+        while placeholder_end + 2 < text.len() && text.as_bytes()[placeholder_end + 2] == b'}' {
+            placeholder_end += 1;
+        }
+
+        let placeholder_content = &text[placeholder_start + 2..placeholder_end];
+
+        if placeholder_start > 0 {
+            highlight_code_segment(
+                command,
+                &replace_escaped(&text[..placeholder_start]),
+                process_snippet,
+            )?;
+        }
+        process_snippet(PageSnippet::Variable(&replace_escaped(placeholder_content)))?;
+
+        text.replace_range(..placeholder_end + 2, "");
+    }
+
     Ok(())
 }
 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -15,6 +15,7 @@ pub enum PageSnippet<T> {
     Linebreak,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 impl<T> PageSnippet<T> {
     pub fn map<F, U>(self, f: F) -> PageSnippet<U>
     where

--- a/src/output.rs
+++ b/src/output.rs
@@ -56,7 +56,7 @@ pub fn print_page(
         }
     } else {
         // Closure that processes a page snippet and writes it to stdout
-        let mut process_snippet = |snip: PageSnippet<'_>| {
+        let mut process_snippet = |snip: PageSnippet<&str>| {
             if snip.is_empty() {
                 Ok(())
             } else {
@@ -81,7 +81,7 @@ pub fn print_page(
 
 fn print_snippet(
     writer: &mut impl Write,
-    snip: PageSnippet<'_>,
+    snip: PageSnippet<&str>,
     style: &StyleConfig,
 ) -> io::Result<()> {
     use PageSnippet::*;


### PR DESCRIPTION
Closes #402

The actual implementation of phrases like

> the outer braces mark the placeholder

from the spec is not super clear, and the code is playing a bit loose with `String`s right now, but I think it produces the correct output.
