### PR TITLE
Add an option to specify a custom config file to be used

### DIFF
--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -11,13 +11,14 @@ Options:
       --edit-page            Edit custom page with `EDITOR`
       --edit-patch           Edit custom patch with `EDITOR`
   -f, --render <FILE>        Render a specific markdown file
-  -p, --platform <PLATFORM>  Override the operating system, can be specified multiple times in order of preference [possible values: linux, macos, sunos, windows, android, freebsd,
-                             netbsd, openbsd, common]
+  -p, --platform <PLATFORM>  Override the operating system, can be specified multiple times in order
+                             of preference [possible values: linux, macos, sunos, windows, android,
+                             freebsd, netbsd, openbsd, common]
   -L, --language <LANGUAGE>  Override the language
   -u, --update               Update the local cache
       --no-auto-update       If auto update is configured, disable it for this run
   -c, --clear-cache          Clear the local cache
-      --config <FILE>        Override config file location
+      --config-path <FILE>   Override config file location
       --pager                Use a pager to page output
   -r, --raw                  Display the raw markdown instead of rendering it
   -q, --quiet                Suppress informational messages

--- a/docs/src/usage.txt
+++ b/docs/src/usage.txt
@@ -11,13 +11,13 @@ Options:
       --edit-page            Edit custom page with `EDITOR`
       --edit-patch           Edit custom patch with `EDITOR`
   -f, --render <FILE>        Render a specific markdown file
-  -p, --platform <PLATFORM>  Override the operating system, can be specified multiple times in order
-                             of preference [possible values: linux, macos, sunos, windows, android,
-                             freebsd, netbsd, openbsd, common]
+  -p, --platform <PLATFORM>  Override the operating system, can be specified multiple times in order of preference [possible values: linux, macos, sunos, windows, android, freebsd,
+                             netbsd, openbsd, common]
   -L, --language <LANGUAGE>  Override the language
   -u, --update               Update the local cache
       --no-auto-update       If auto update is configured, disable it for this run
   -c, --clear-cache          Clear the local cache
+      --config <FILE>        Override config file location
       --pager                Use a pager to page output
   -r, --raw                  Display the raw markdown instead of rendering it
   -q, --quiet                Suppress informational messages

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -174,8 +174,8 @@ impl Cache {
             if let Ok(mtime) = metadata.modified() {
                 let now = SystemTime::now();
                 return now.duration_since(mtime).ok();
-            };
-        };
+            }
+        }
         None
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,8 +74,8 @@ pub(crate) struct Cli {
     #[arg(short = 'c', long = "clear-cache")]
     pub clear_cache: bool,
 
-    /// Use the specified file as config instead of the default
-    #[arg(long = "config")]
+    /// Override config file location
+    #[arg(long = "config", value_name = "FILE")]
     pub config: Option<PathBuf>,
 
     /// Use a pager to page output

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,8 +75,8 @@ pub(crate) struct Cli {
     pub clear_cache: bool,
 
     /// Override config file location
-    #[arg(long = "config", value_name = "FILE")]
-    pub config: Option<PathBuf>,
+    #[arg(long = "config-path", value_name = "FILE")]
+    pub config_path: Option<PathBuf>,
 
     /// Use a pager to page output
     #[arg(long = "pager", requires = "command_or_file")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,10 @@ pub(crate) struct Cli {
     #[arg(short = 'c', long = "clear-cache")]
     pub clear_cache: bool,
 
+    /// Use the specified file as config instead of the default
+    #[arg(long = "config")]
+    pub config: Option<PathBuf>,
+
     /// Use a pager to page output
     #[arg(long = "pager", requires = "command_or_file")]
     pub pager: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -483,15 +483,12 @@ impl Config {
 
         let raw_config = match File::open(config_file_path.path()) {
             Ok(file) => RawConfig::load(file)?,
+            Err(e) if e.kind() == ErrorKind::NotFound => RawConfig::default(),
             Err(e) => {
-                if e.kind().eq(&ErrorKind::NotFound) {
-                    RawConfig::default()
-                } else {
-                    bail!(
-                        "Failed to open config file at {}",
-                        config_file_path.path().display()
-                    );
-                }
+                return Err(e).context(format!(
+                    "Failed to open config file at {}",
+                    config_file_path.path().display()
+                ));
             }
         };
         let config =

--- a/src/config.rs
+++ b/src/config.rs
@@ -554,22 +554,29 @@ pub fn get_default_config_path() -> Result<PathWithSource> {
 }
 
 /// Create default config file.
-pub fn make_default_config() -> Result<PathBuf> {
-    let (config_dir, _) = get_config_dir()?;
-
-    // Ensure that config directory exists
-    if config_dir.exists() {
-        ensure!(
-            config_dir.is_dir(),
-            "Config directory could not be created: {} already exists but is not a directory",
-            config_dir.to_string_lossy(),
-        );
+/// path: Can be specified to create the config in that path instead of
+/// the default path.
+pub fn make_default_config(path: Option<&Path>) -> Result<PathBuf> {
+    let config_file_path = if let Some(p) = path {
+        p.into()
     } else {
-        fs::create_dir_all(&config_dir).context("Could not create config directory")?;
-    }
+        let (config_dir, _) = get_config_dir()?;
+
+        // Ensure that config directory exists
+        if config_dir.exists() {
+            ensure!(
+                config_dir.is_dir(),
+                "Config directory could not be created: {} already exists but is not a directory",
+                config_dir.to_string_lossy(),
+            );
+        } else {
+            fs::create_dir_all(&config_dir).context("Could not create config directory")?;
+        }
+
+        config_dir.join(CONFIG_FILE_NAME)
+    };
 
     // Ensure that a config file doesn't get overwritten
-    let config_file_path = config_dir.join(CONFIG_FILE_NAME);
     ensure!(
         !config_file_path.is_file(),
         "A configuration file already exists at {}, no action was taken.",

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn update_cache(cache: &Cache, archive_source: &str, quietly: bool) -> Result<()
 }
 
 /// Show file paths
-fn show_paths(config: &Config) {
+fn show_paths(custom_config_path: Option<&Path>, config: &Config) {
     let config_dir = get_config_dir().map_or_else(
         |e| format!("[Error: {e}]"),
         |(mut path, source)| {
@@ -153,7 +153,7 @@ fn show_paths(config: &Config) {
             }
         },
     );
-    let config_path = get_config_path().map_or_else(
+    let config_path = get_config_path(custom_config_path).map_or_else(
         |e| format!("[Error: {e}]"),
         |(path, _)| path.display().to_string(),
     );
@@ -280,7 +280,7 @@ fn main() -> ExitCode {
 fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     // Look up config file, if none is found fall back to default config.
     let config =
-        Config::load(args.config.clone(), enable_styles).context("Could not load config")?;
+        Config::load(args.config.as_deref(), enable_styles).context("Could not load config")?;
 
     let custom_pages_dir = config
         .directories
@@ -309,7 +309,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
 
     // Show various paths
     if args.show_paths {
-        show_paths(&config);
+        show_paths(args.config.as_deref(), &config);
     }
 
     // Create a basic config and exit

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,8 @@ fn main() -> ExitCode {
 
 fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     // Look up config file, if none is found fall back to default config.
-    let config = Config::load(enable_styles).context("Could not load config")?;
+    let config =
+        Config::load(args.config.clone(), enable_styles).context("Could not load config")?;
 
     let custom_pages_dir = config
         .directories

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,8 +173,8 @@ fn show_paths(config: &Config) {
     println!("Custom pages dir: {custom_pages_dir}");
 }
 
-fn create_config() -> Result<()> {
-    let config_file_path = make_default_config().context("Could not create seed config")?;
+fn create_config(path: Option<&Path>) -> Result<()> {
+    let config_file_path = make_default_config(path).context("Could not create seed config")?;
     eprintln!(
         "Successfully created seed config file here: {}",
         config_file_path.to_str().unwrap()
@@ -278,12 +278,12 @@ fn main() -> ExitCode {
 fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     // Look up config file, if none is found fall back to default config.
     debug!("Loading config");
-    let config = match args.config_path {
-        Some(ref path) => {
-            Config::load(path, enable_styles).context("Could not load config from given path")?
-        }
-        None => Config::load_default_path(enable_styles)
-            .context("Could not load config from default path")?,
+    let config = if args.config_path.is_some() && !args.seed_config {
+        Config::load(args.config_path.as_deref().unwrap(), enable_styles)
+            .context("Could not load config from given path")?
+    } else {
+        Config::load_default_path(enable_styles)
+            .context("Could not load config from default path")?
     };
 
     let custom_pages_dir = config
@@ -318,7 +318,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
 
     // Create a basic config and exit
     if args.seed_config {
-        create_config()?;
+        create_config(args.config_path.as_deref())?;
         return Ok(ExitCode::SUCCESS);
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -71,7 +71,7 @@ pub fn print_page(
             !config.display.compact,
         )
         .context("Could not write to stdout")?;
-    };
+    }
 
     // We're done outputting data, flush stdout now!
     handle.flush().context("Could not flush stdout")?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,6 +205,8 @@ pub enum PathSource {
     EnvVar,
     /// Config file
     ConfigFile,
+    /// CLI argument override
+    Override,
 }
 
 impl fmt::Display for PathSource {
@@ -216,6 +218,7 @@ impl fmt::Display for PathSource {
                 Self::OsConvention => "OS convention",
                 Self::EnvVar => "env variable",
                 Self::ConfigFile => "config file",
+                Self::Override => "override by flag",
             }
         )
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -206,7 +206,7 @@ pub enum PathSource {
     /// Config file
     ConfigFile,
     /// CLI argument override
-    Override,
+    Cli,
 }
 
 impl fmt::Display for PathSource {
@@ -218,7 +218,7 @@ impl fmt::Display for PathSource {
                 Self::OsConvention => "OS convention",
                 Self::EnvVar => "env variable",
                 Self::ConfigFile => "config file",
-                Self::Override => "override by flag",
+                Self::Cli => "command line argument",
             }
         )
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -237,6 +237,21 @@ fn test_load_the_correct_config() {
 }
 
 #[test]
+fn test_fail_on_custom_config_path_is_directory() {
+    let testenv = TestEnv::new();
+    testenv
+        .command()
+        .args([
+            "--config-path",
+            testenv.config_dir().to_str().unwrap(),
+            "sl",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("The given path doesn't point to a file"));
+}
+
+#[test]
 fn test_missing_cache() {
     TestEnv::new()
         .command()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -501,6 +501,20 @@ fn test_setup_seed_config() {
         .stderr(contains("Successfully created seed config file here"));
 
     assert!(testenv.config_dir().join("config.toml").is_file());
+
+    let custom_config_path = testenv.config_dir().join("config_custom.toml");
+    testenv
+        .command()
+        .args([
+            "--seed-config",
+            "--config-path",
+            custom_config_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stderr(contains("Successfully created seed config file here"));
+
+    assert!(custom_config_path.is_file());
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -239,6 +239,11 @@ fn test_load_the_correct_config() {
 #[test]
 fn test_fail_on_custom_config_path_is_directory() {
     let testenv = TestEnv::new();
+    let error = if cfg!(windows) {
+        "Access is denied"
+    } else {
+        "Is a directory"
+    };
     testenv
         .command()
         .args([
@@ -248,7 +253,7 @@ fn test_fail_on_custom_config_path_is_directory() {
         ])
         .assert()
         .failure()
-        .stderr(contains("Is a directory"));
+        .stderr(contains(error));
 }
 
 #[test]


### PR DESCRIPTION
Inspired by #141
Closes #107

Note: In the original PR, some modifications were made so that the path specified by the config file flag can be used as the output path of the seed-config option. I chose not to do that here for now, because I think the meaning of this usage wouldn't be visible and clear to the user. Let me know if you think otherwise.