### PR TITLE
 Add `search.languages` and `updates.download_languages` settings

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Configuration](./config.md)
   - [Section: \[display\]](./config_display.md)
   - [Section: \[style\]](./config_style.md)
+  - [Section: \[search\]](./config_search.md)
   - [Section: \[updates\]](./config_updates.md)
   - [Section: \[directories\]](./config_directories.md)
 - [Tips and Tricks](./tips_and_tricks.md)

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -22,7 +22,7 @@ On Linux, this will usually be `~/.config/tealdeer/config.toml`.
 Here's an example configuration file. Note that this example does not contain
 all possible config options. For details on the things that can be configured,
 please refer to the subsections of this documentation page
-([display](config_display.html), [style](config_style.html),
+([display](config_display.html), [style](config_style.html), [search](config_search.html),
 [updates](config_updates.html) or [directories](config_directories.html)).
 
 ```toml

--- a/docs/src/config_search.md
+++ b/docs/src/config_search.md
@@ -1,0 +1,14 @@
+# Section: \[search\]
+
+This config section is used to configure the page search in the cache.
+The settings apply to `tldr <page>` and `tldr --list`.
+
+## `languages`
+
+The list of languages that should be considered when searching.
+If unspecified, the list of languages will be inferred from the `LANG` and `LANGUAGE` environment variables.
+Either way, the language used can be overwritten using the `--language` command line flag.
+
+    [search]
+    # Show pages in German if available, otherwise show in English
+    languages = ["de", "en"]

--- a/docs/src/config_updates.md
+++ b/docs/src/config_updates.md
@@ -1,5 +1,7 @@
 # Section: \[updates\]
 
+This config section contains settings related to updating the tealdeer cache.
+
 ## Automatic updates
 
 Tealdeer can refresh the cache automatically when it is outdated. This
@@ -24,7 +26,23 @@ is set to `false`.
     auto_update = true
     auto_update_interval_hours = 24
 
-### archive_source
+## Download configuration
+
+### `download_languages`
+
+The list of languages which should be downloaded when updating.
+If unspecified, the languages listed in the `search.languages` setting are used.
+Thus, this setting is the most useful to instruct tealdeer to download pages in additional languages that are not searched by default.
+Either way, the language used can be overwritten using the `--language` command line flag.
+
+    [search]
+    languages = ["de", "en"]
+
+    [updates]
+    # sometimes I like to read the Italian description
+    download_languages = ["de", "en", "it"]
+
+### `archive_source`
 
 URL for the location of the tldr pages archive. By default the pages are
 fetched from the latest `tldr-pages/tldr` GitHub release.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,13 +14,13 @@ use ureq::{
 };
 use zip::ZipArchive;
 
-use crate::{config::TlsBackend, types::PlatformType};
+use crate::{
+    config::{Language, TlsBackend},
+    types::PlatformType,
+};
 
 pub static TLDR_PAGES_DIR: &str = "tldr-pages";
 pub static TLDR_OLD_PAGES_DIR: &str = "tldr-master";
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct Language<'a>(pub &'a str);
 
 #[derive(Clone)]
 pub struct CacheConfig<'a> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -623,42 +623,42 @@ pub fn make_default_config(path: Option<&Path>) -> Result<PathBuf> {
     Ok(config_file_path)
 }
 
-#[test]
-fn test_serialize_deserialize() {
-    let raw_config = RawConfig::default();
-    let serialized = toml::to_string(&raw_config).unwrap();
-    let deserialized: RawConfig = toml::from_str(&serialized).unwrap();
-    assert_eq!(raw_config, deserialized);
-}
-
-#[test]
-fn test_relative_path_resolution() {
-    let mut raw_config = RawConfig::default();
-    raw_config.directories.cache_dir = Some("../cache".into());
-    raw_config.directories.custom_pages_dir = Some("../custom_pages".into());
-
-    let config = Config::from_raw(
-        &raw_config,
-        PathWithSource {
-            path: PathBuf::from("/path/to/config/config.toml"),
-            source: PathSource::OsConvention,
-        },
-    )
-    .unwrap();
-
-    assert_eq!(
-        config.directories.cache_dir.path(),
-        Path::new("/path/to/config/../cache")
-    );
-    assert_eq!(
-        config.directories.custom_pages_dir.unwrap().path(),
-        Path::new("/path/to/config/../custom_pages")
-    );
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn serialize_deserialize() {
+        let raw_config = RawConfig::default();
+        let serialized = toml::to_string(&raw_config).unwrap();
+        let deserialized: RawConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(raw_config, deserialized);
+    }
+
+    #[test]
+    fn relative_path_resolution() {
+        let mut raw_config = RawConfig::default();
+        raw_config.directories.cache_dir = Some("../cache".into());
+        raw_config.directories.custom_pages_dir = Some("../custom_pages".into());
+
+        let config = Config::from_raw(
+            &raw_config,
+            PathWithSource {
+                path: PathBuf::from("/path/to/config/config.toml"),
+                source: PathSource::OsConvention,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.directories.cache_dir.path(),
+            Path::new("/path/to/config/../cache")
+        );
+        assert_eq!(
+            config.directories.custom_pages_dir.unwrap().path(),
+            Path::new("/path/to/config/../custom_pages")
+        );
+    }
 
     mod language {
         use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -701,6 +701,15 @@ mod test {
         }
 
         #[test]
+        fn with_encoding() {
+            let lang_list = get_languages(Some("de_DE.UTF-8"), None);
+            assert_eq!(
+                lang_list,
+                [Language("de_DE"), Language("de"), Language("en")]
+            );
+        }
+
+        #[test]
         fn ignore_posix_and_c() {
             let lang_list = get_languages(Some("POSIX"), None);
             assert_eq!(lang_list, [Language("en")]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use anyhow::{anyhow, Context, Result};
 use app_dirs::AppInfo;
 use cache::{CacheConfig, TLDR_OLD_PAGES_DIR};
 use clap::Parser;
-use config::{get_languages_from_env, ConfigLoader, Language, StyleConfig, TlsBackend};
+use config::{ConfigLoader, Language, StyleConfig, TlsBackend};
 use log::debug;
 
 mod cache;
@@ -250,10 +250,10 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     }
 
     let platforms = compute_platforms(args.platforms.as_ref());
-    let languages = args
-        .language
-        .as_deref()
-        .map_or_else(get_languages_from_env, |lang| vec![Language(lang)]);
+    let languages = match args.language.as_deref() {
+        Some(lang) => &[Language(lang)] as &[_],
+        None => &config.search.languages,
+    };
 
     let cache_config = CacheConfig {
         pages_directory: &config.directories.cache_dir.path().join(TLDR_PAGES_DIR),
@@ -263,7 +263,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
             .as_ref()
             .map(PathWithSource::path),
         platforms: &platforms,
-        languages: &languages,
+        languages,
     };
 
     // TODO: remove in tealdeer 1.9

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -996,6 +996,30 @@ fn test_search_language_precedence() {
     run(env_cases);
 }
 
+#[cfg_attr(feature = "ignore-online-tests", ignore = "online test")]
+#[test]
+fn test_update_language_arg() {
+    let testenv = TestEnv::new();
+    testenv
+        .command()
+        .env("LANG", "it")
+        .arg("--update")
+        .assert()
+        .success()
+        .stderr(contains("it"))
+        .stderr(contains("en"));
+
+    testenv
+        .command()
+        .env("LANG", "en")
+        .args(["--language", "it"])
+        .arg("--update")
+        .assert()
+        .success()
+        .stderr(contains("it"))
+        .stderr(contains("en").not());
+}
+
 #[test]
 fn test_list_flag_rendering() {
     let testenv = TestEnv::new().write_custom_pages_config();


### PR DESCRIPTION
Closes #251

Best reviewed commit by commit.

Test for the download_languages setting are just destined to be flaky if we update from the upstream repository. I would just test it by hand for now and defer automatic tests until we have #390.