### PR TITLE
Add config option to search all known platforms

### DIFF
--- a/docs/src/config_search.md
+++ b/docs/src/config_search.md
@@ -12,3 +12,13 @@ Either way, the language used can be overwritten using the `--language` command 
     [search]
     # Show pages in German if available, otherwise show in English
     languages = ["de", "en"]
+
+## `try_all_platforms`
+
+Whether or not all known platforms should be tried when searching for pages.
+For example, pages for Windows would also be found when running on Linux.
+By default, this setting is `true`.
+
+    [search]
+    # Don't use extra platforms in search
+    try_all_platforms = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,6 +217,7 @@ struct RawDirectoriesConfig {
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 struct RawSearchConfig {
     pub languages: Option<Vec<String>>,
+    pub try_all_platforms: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -301,6 +302,7 @@ pub struct DirectoriesConfig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SearchConfig<'a> {
     pub languages: Vec<Language<'a>>,
+    pub try_all_platforms: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -432,6 +434,7 @@ impl<'a> Config<'a> {
                 .map_or_else(get_languages_from_env, |langs| {
                     langs.iter().map(|lang| Language(lang)).collect()
                 }),
+            try_all_platforms: raw_config.search.try_all_platforms.unwrap_or(true),
         };
 
         let updates = UpdatesConfig {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -73,7 +73,8 @@ impl TestEnv {
     }
     fn init_config(&self) {
         self.append_to_config(format!(
-            "directories.cache_dir = '{}'\n",
+            "directories.cache_dir = '{}'\n
+            search.try_all_platforms = false\n",
             self.cache_dir().to_str().unwrap(),
         ));
     }
@@ -713,6 +714,32 @@ fn test_os_specific_page() {
         .args(["--platform", "sunos", "truss"])
         .assert()
         .success();
+}
+
+#[test]
+fn test_try_all_platforms() {
+    let testenv = TestEnv::new().create_secondary_config();
+
+    testenv.add_os_entry("sunos", "sunos-command", "");
+
+    let mut cmd = testenv.command();
+    cmd.args([
+        "--config-path",
+        testenv
+            .config_dir()
+            .join("config-secondary.toml")
+            .to_str()
+            .unwrap(),
+        "sunos-command",
+    ]);
+
+    cmd.assert().success();
+
+    testenv.append_to_secondary_config("search.try_all_platforms = false");
+    cmd.assert().failure();
+
+    cmd.args(["--platform", "sunos"]);
+    cmd.assert().success();
 }
 
 #[test]


### PR DESCRIPTION
Closes #278

The current version is implemented to also use extra platforms when passing `--platform`, so for example running `tldr --platform linux` would still show Windows pages with the default config.
We could also make it so that the setting is only taken if `--platform` is not used.
I actually suspect that the latter would be more pleasant.

What do you think? @k12ish @marchersimon @osalbahr @erickguan @MHS-0
