### PR TITLE
Silence the missing-cache message under --quiet

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -349,20 +349,22 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     } else if args.list || !command.is_empty() {
         // Cache is needed for these commands to work
         let Some(cache) = Cache::open(cache_config)? else {
-            print_error(
-                enable_styles,
-                &anyhow::anyhow!(
-                    "Page cache not found. Please run `tldr --update` to download the cache."
-                ),
-            );
-            println!("\nNote: You can optionally enable automatic cache updates by adding the");
-            println!("following config to your config file:\n");
-            println!("  [updates]");
-            println!("  auto_update = true\n");
-            println!("The path to your config file can be looked up with `tldr --show-paths`.");
-            println!("To create an initial config file, use `tldr --seed-config`.\n");
-            println!("You can find more tips and tricks in our docs:\n");
-            println!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
+            if !args.quiet {
+                print_error(
+                    enable_styles,
+                    &anyhow::anyhow!(
+                        "Page cache not found. Please run `tldr --update` to download the cache."
+                    ),
+                );
+                println!("\nNote: You can optionally enable automatic cache updates by adding the");
+                println!("following config to your config file:\n");
+                println!("  [updates]");
+                println!("  auto_update = true\n");
+                println!("The path to your config file can be looked up with `tldr --show-paths`.");
+                println!("To create an initial config file, use `tldr --seed-config`.\n");
+                println!("You can find more tips and tricks in our docs:\n");
+                println!("  https://tealdeer-rs.github.io/tealdeer/config_updates.html");
+            }
 
             return Ok(ExitCode::FAILURE);
         };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -469,6 +469,21 @@ fn test_quiet_failures() {
 }
 
 #[test]
+fn test_quiet_missing_cache() {
+    let testenv = TestEnv::new();
+
+    for args in [["--list", "--quiet"], ["sl", "--quiet"]] {
+        testenv
+            .command()
+            .args(args)
+            .assert()
+            .failure()
+            .stdout(is_empty())
+            .stderr(is_empty());
+    }
+}
+
+#[test]
 fn test_quiet_old_cache() {
     let testenv = TestEnv::new().install_default_cache();
 


### PR DESCRIPTION
`--quiet` did not silence the missing-cache message. With an empty cache:

```
$ tldr --list --quiet
Page cache not found. Please run `tldr --update` to download the cache.

Note: You can optionally enable automatic cache updates by adding the
[8 more lines]
rc=1
```

Both streams were affected, which I checked by redirecting them separately: the error goes to stderr via `print_error`, and the 8-line guidance block goes to stdout as bare `println!`. The stdout half is what pollutes `tldr --quiet --list`, which docs/src/tips_and_tricks.md recommends.

The arm at src/main.rs:349 had no `args.quiet` check, unlike its siblings further down.

Now gated on `!args.quiet`. The `ExitCode::FAILURE` return stays outside the guard, so quiet means silent, not successful.

Verification: with `--quiet`, both `--list --quiet` and `sl --quiet` give empty stdout, empty stderr, exit 1. Without it, the full message is unchanged. `cargo test -- --test-threads 1` gives 53 passed, `cargo fmt --all -- --check` is clean. `cargo clippy --all-targets --features logging` has one warning, `default_trait_access` at src/config.rs:802, which is pre-existing; I confirmed it on a stashed clean tree.

The new test covers both command shapes and asserts the exit status as well as the empty streams. Forcing the guard true makes it fail.

I did not touch CHANGELOG.md since there is no unreleased section, happy to add an entry wherever you want it.

AI disclosure: this contribution was written with the help of an AI tool (Claude). I reproduced the bug, ran the gates and reviewed the change myself.
