### PR TITLE
Allow --no-auto-update without a command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,7 +69,7 @@ pub(crate) struct Cli {
     pub update: bool,
 
     /// If auto update is configured, disable it for this run
-    #[arg(long = "no-auto-update", requires = "command_or_file")]
+    #[arg(long = "no-auto-update")]
     pub no_auto_update: bool,
 
     /// Clear the local cache

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1298,6 +1298,19 @@ fn test_autoupdate_cache() {
     check_cache_updated(false);
 }
 
+/// Regression test: `--no-auto-update` should be usable together with `--list`,
+/// since the auto-update gate in `main.rs` also applies to `--list`.
+#[test]
+fn test_no_auto_update_with_list() {
+    let testenv = TestEnv::new().install_default_cache();
+
+    testenv
+        .command()
+        .args(["--list", "--no-auto-update"])
+        .assert()
+        .success();
+}
+
 /// End-end test to ensure .page.md files overwrite pages in cache_dir
 #[test]
 fn test_custom_page_overwrites() {


### PR DESCRIPTION
Written with AI assistance (Claude Opus 5), per the AI policy. I have checked it and reproduced everything below myself.

`--no-auto-update` cannot be combined with `--list`:

```
$ tldr --list --no-auto-update
error: the following required arguments were not provided:
  <COMMAND|--render <FILE>>
```

But `--list` reaches the gate the flag controls. `main.rs:313` is `if args.update || config.updates.auto_update && !args.no_auto_update`, and `main.rs:349` shows `args.list` arriving in that same region, so a `--list` run does auto-update and cannot be told not to.

I dropped the `requires = "command_or_file"` rather than adding `list` to the group, because `--show-paths` reaches the gate too. It calls `show_paths` at `main.rs:243` without returning, so it falls through; `--clear-cache` and `--seed-config` do return first, at 310 and 250, and the flag is simply inert for those.

Test in `tests/lib.rs` asserting the combination is accepted. It fails with the old constraint on clap exit code 2. `cargo test` passes, 31 unit and 53 integration.
