### PR TITLE
ci: build with `--locked`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,23 @@ jobs:
       - run: mkdir artifacts
       - name: Build with default features
         run: |
-          cargo build
+          cargo build --locked
           cp target/debug/tldr${{ matrix.exe_suffix}} artifacts/tldr-default${{ matrix.exe_suffix}}
       - name: Build with logging and Rustls with webpki roots
         run: |
-          cargo build --features logging,rustls-with-webpki-roots --no-default-features
+          cargo build --locked --features logging,rustls-with-webpki-roots --no-default-features
           cp target/debug/tldr${{ matrix.exe_suffix}} artifacts/tldr-logging-rustls-webpki${{ matrix.exe_suffix}}
       - name: Build with native TLS backend
         run: |
           # expects runners have the proper Native SSL library
-          cargo build --features native-tls --no-default-features
+          cargo build --locked --features native-tls --no-default-features
           cp target/debug/tldr${{ matrix.exe_suffix}} artifacts/tldr-native-tls${{ matrix.exe_suffix}}
       - uses: actions/upload-artifact@v7
         with:
           name: tldr-debug-build-${{ matrix.platform }}-rust-${{ matrix.toolchain }}
           path: artifacts/
       - name: Run tests
-        run: cargo test -- --test-threads 1
+        run: cargo test --locked -- --test-threads 1
 
   clippy:
     name: run clippy lints
@@ -56,7 +56,7 @@ jobs:
            toolchain: stable
            components: clippy
        - name: run clippy lints
-         run: cargo clippy --all-targets --features logging
+         run: cargo clippy --locked --all-targets --features logging
 
   fmt:
     name: run rustfmt
@@ -84,10 +84,10 @@ jobs:
         with:
             toolchain: stable
       - name: Build
-        run: cargo build
+        run: cargo build --locked
       - name: Ensure that docs can be built
         run: cd docs && mdbook build
       - name: Generate usage string
-        run: cargo run -- --help > docs/src/usage-actual.txt
+        run: cargo run --locked -- --help > docs/src/usage-actual.txt
       - name: Ensure that usage string is up to date
         run: diff docs/src/usage{,-actual}.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Pull Docker image
         run: docker pull messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }}
       - name: Build in Docker
-        run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} cargo build --release
+        run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} cargo build --locked --release
       - name: Strip binary
         run: docker run --rm -i -v "$(pwd)":/home/rust/src messense/rust-musl-cross:${{ matrix.arch }}-${{ matrix.libc }} musl-strip -s /home/rust/src/target/${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}/release/tldr
       - uses: actions/upload-artifact@v7
@@ -93,7 +93,7 @@ jobs:
           toolchain: stable
           targets: "${{ matrix.arch }}-apple-darwin"
       - name: Build
-        run: cargo build --release --target ${{ matrix.arch }}-apple-darwin
+        run: cargo build --locked --release --target ${{ matrix.arch }}-apple-darwin
       - uses: actions/upload-artifact@v7
         with:
           name: "tealdeer-macos-${{ matrix.arch }}"
@@ -116,7 +116,7 @@ jobs:
             toolchain: stable
             targets: "${{ matrix.arch }}-pc-windows-msvc"
       - name: Build
-        run: cargo build --release --target ${{ matrix.arch }}-pc-windows-msvc
+        run: cargo build --locked --release --target ${{ matrix.arch }}-pc-windows-msvc
       - uses: actions/upload-artifact@v7
         with:
           name: "tealdeer-windows-${{ matrix.arch }}-msvc"


### PR DESCRIPTION
## Summary

- add `--locked` to feature builds, tests, Clippy, and documentation generation
- add `--locked` to Linux, macOS, and Windows release builds
- ensure CI and published binaries use the committed dependency resolution

The project is a binary application with a committed `Cargo.lock`, so silently resolving a different dependency graph on a runner can hide manifest/lockfile drift and make releases less reproducible.

## Validation

- `cargo check --locked --all-targets --features logging`
- `cargo check --locked --features native-tls --no-default-features`

Prepared with assistance from OpenAI Codex; the commit includes a `Co-authored-by` trailer.