### PR TITLE
ci: test on native Windows ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
     name: run tests
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
         toolchain: [stable, 1.87.0] # MSRV
         include:
           - platform: windows-latest
+            exe_suffix: .exe
+          - platform: windows-11-arm
             exe_suffix: .exe
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Adds `windows-11-arm` to the regular stable and MSRV test matrix, as requested in the follow-up to #502. This verifies Windows ARM64 on every PR instead of only when producing release artifacts.

The workflow change was prepared with AI assistance and reviewed and tested by me.