### PR TITLE
fix: --quiet does not suppress three informational messages

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -77,10 +77,6 @@ impl<'a> Cache<'a> {
                 config.pages_directory.display(),
             )
         })?;
-        eprintln!(
-            "Successfully created cache directory `{}`.",
-            config.pages_directory.display(),
-        );
 
         Ok((Cache { config }, true))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -618,7 +618,11 @@ impl<'a> Config<'a> {
     ///
     /// For this, some values need to be converted to other types and some
     /// defaults need to be set (sometimes based on env variables).
-    fn from_raw(raw_config: &'a RawConfig, config_file_path: PathWithSource) -> Result<Self> {
+    fn from_raw(
+        raw_config: &'a RawConfig,
+        config_file_path: PathWithSource,
+        quiet: bool,
+    ) -> Result<Self> {
         let style = (&raw_config.style).into();
         let display = (&raw_config.display).into();
         let search: SearchConfig<'a> = (&raw_config.search).into();
@@ -654,7 +658,9 @@ impl<'a> Config<'a> {
             // For backwards compatibility reasons, the cache directory can be
             // overridden using an env variable. This is deprecated and will be
             // phased out in the future.
-            eprintln!("Warning: The ${cache_dir_env_var} env variable is deprecated, use the `cache_dir` option in the config file instead.");
+            if !quiet {
+                eprintln!("Warning: The ${cache_dir_env_var} env variable is deprecated, use the `cache_dir` option in the config file instead.");
+            }
             PathWithSource {
                 path: PathBuf::from(env_var),
                 source: PathSource::EnvVar,
@@ -833,8 +839,9 @@ impl ConfigLoader {
     }
 
     /// Parse the read [`RawConfig`] into a [`Config`].
-    pub fn load(&self) -> Result<Config<'_>> {
-        Config::from_raw(&self.raw, self.path.clone())
+    /// `quiet`: If true, informational messages are suppressed.
+    pub fn load(&self, quiet: bool) -> Result<Config<'_>> {
+        Config::from_raw(&self.raw, self.path.clone(), quiet)
             .context("Could not process raw config into rich config")
     }
 }
@@ -964,6 +971,7 @@ mod test {
                 path: PathBuf::from("/path/to/config/config.toml"),
                 source: PathSource::OsConvention,
             },
+            false,
         )
         .unwrap();
 
@@ -991,6 +999,7 @@ mod test {
                 path: PathBuf::from("/path/to/config/config.toml"),
                 source: PathSource::OsConvention,
             },
+            false,
         )
         .unwrap();
 
@@ -1056,7 +1065,7 @@ mod test {
                     $overrides,
                 )
                 .unwrap();
-                let $config = loader.load().unwrap();
+                let $config = loader.load(false).unwrap();
             };
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,7 +207,7 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
         _ => ConfigLoader::read_default_path(&args.override_config)
             .context("Could not read config from default path")?,
     };
-    let mut config = config_loader.load()?;
+    let mut config = config_loader.load(args.quiet)?;
 
     // Override styles if needed
     if !enable_styles {
@@ -300,7 +300,9 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
     };
     if let Ok(Some(old_cache)) = Cache::open(old_config) {
         old_cache.clear()?;
-        eprintln!("Cleared pages from old cache location.");
+        if !args.quiet {
+            eprintln!("Cleared pages from old cache location.");
+        }
     }
 
     if args.clear_cache {
@@ -312,6 +314,12 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
 
     let cache = if args.update || config.updates.auto_update && !args.no_auto_update {
         let (mut cache, was_created) = Cache::open_or_create(cache_config)?;
+        if was_created && !args.quiet {
+            eprintln!(
+                "Successfully created cache directory `{}`.",
+                cache.config().pages_directory.display(),
+            );
+        }
         if was_created || args.update || cache.age()? >= config.updates.auto_update_interval {
             let result = update_cache(
                 &mut cache,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -509,6 +509,51 @@ fn test_quiet_old_cache() {
 }
 
 #[test]
+fn test_quiet_old_pages_directory() {
+    let testenv = TestEnv::new().install_default_cache();
+    fs::rename(
+        testenv.cache_dir().join(TLDR_PAGES_DIR),
+        testenv.cache_dir().join(TLDR_OLD_PAGES_DIR),
+    )
+    .unwrap();
+
+    testenv
+        .command()
+        .args(["--list", "--quiet"])
+        .assert()
+        .failure()
+        .stderr(contains("Cleared pages from old cache location.").not());
+}
+
+#[test]
+fn test_quiet_deprecated_cache_dir_env_var() {
+    let testenv = TestEnv::new().install_default_cache();
+
+    testenv
+        .command()
+        .env("TEALDEER_CACHE_DIR", testenv.cache_dir().to_str().unwrap())
+        .args(["which", "--quiet"])
+        .assert()
+        .success()
+        .stderr(contains("env variable is deprecated").not());
+}
+
+#[test]
+fn test_quiet_cache_directory_creation() {
+    let testenv = TestEnv::new();
+    // Point at an unreachable archive so that no network access is needed. The cache directory is
+    // created before the download is attempted.
+    testenv.append_to_config("updates.archive_source = 'http://127.0.0.1:1/'\n");
+
+    testenv
+        .command()
+        .args(["--update", "--quiet"])
+        .assert()
+        .failure()
+        .stderr(contains("Successfully created cache directory").not());
+}
+
+#[test]
 fn test_warn_cache_age_never() {
     let testenv = TestEnv::new().install_default_cache();
 


### PR DESCRIPTION
## What's broken

Three informational messages ignore `--quiet`. Part of #268, where a maintainer confirmed that `--quiet` should not display warnings.

## Repro

stderr with `--quiet`, before:

```
$ tldr --list --quiet
Cleared pages from old cache location.

$ TEALDEER_CACHE_DIR=/tmp/c tldr --list --quiet
Warning: The $TEALDEER_CACHE_DIR env variable is deprecated, use the `cache_dir` option in the config file instead.

$ tldr --update --quiet
Successfully created cache directory `/tmp/c/tldr-pages`.
```

After, all three print nothing. Without `--quiet` all three still print.

## The fix

An `if !quiet` guard on the first two, matching `clear_cache` and `update_cache`. The creation notice moved from `Cache::open_or_create` to `main.rs`, since the flag is not reachable in `cache.rs`, so `ConfigLoader::load` now takes `quiet`. tealdeer is a binary-only crate, so that signature is not public API.

## Verification

Three tests in `tests/lib.rs`, one per message. Reverting the guards fails exactly those three, the other four `test_quiet_*` still pass. The creation test points `archive_source` at `127.0.0.1:1` so it stays offline.

`cargo test --release` passes, 57 plus 31. `cargo fmt --check` clean. `cargo clippy --all-targets -- -D warnings` reports one `default_trait_access` at `src/config.rs:808`, identical on a clean checkout, and not a line I touched.

No CHANGELOG entry: RELEASING.md shows it is written at release time.

*Per the AI policy: written with AI assistance (Claude Code). I ran the binary for each of the three messages myself, with and without `--quiet`, and ran the mutation check on each guard.*
