### PR TITLE
fix: C.UTF-8 and POSIX.UTF-8 are not ignored as locales

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -501,12 +501,21 @@ fn get_languages<'a>(
             continue;
         }
 
+        // Strip the encoding suffix (e.g. `de_DE.UTF-8` -> `de_DE`)
+        let locale = locale.split('.').next().unwrap_or(locale);
+
+        // `C` and `POSIX` are not languages and must be ignored
+        if locale == "C" || locale == "POSIX" {
+            info!("Skipping locale string without language: {locale}");
+            continue;
+        }
+
         // Language plus country code (e.g. `en_US`)
         if locale.len() >= 5 && locale.chars().nth(2) == Some('_') {
             lang_list.push(Language(&locale[..5]));
         }
         // Language code only (e.g. `en`)
-        if locale.len() >= 2 && locale != "POSIX" {
+        if locale.len() >= 2 {
             lang_list.push(Language(&locale[..2]));
         }
     }
@@ -1149,6 +1158,14 @@ mod test {
             assert_eq!(lang_list, [Language("en")]);
             let lang_list = get_languages(Some("C"), None);
             assert_eq!(lang_list, [Language("en")]);
+        }
+
+        #[test]
+        fn ignore_posix_and_c_with_encoding() {
+            let lang_list = get_languages(Some("C.UTF-8"), None);
+            assert_eq!(lang_list, [Language("en")]);
+            let lang_list = get_languages(Some("de"), Some("C.UTF-8:POSIX.UTF-8"));
+            assert_eq!(lang_list, [Language("de"), Language("en")]);
         }
 
         #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1134,6 +1134,27 @@ fn test_search_language_precedence() {
     run(env_cases);
 }
 
+/// Regression test: `C` and `POSIX` must be ignored even when the locale
+/// carries an encoding suffix, e.g. `C.UTF-8`.
+#[test]
+fn test_search_language_ignores_c_and_posix_with_encoding() {
+    let testenv = TestEnv::new();
+    testenv.add_lang_entry("en", "in-english", "");
+    // Pages in a directory named after the truncated locale must not be found.
+    testenv.add_lang_entry("C.", "bogus-c", "");
+    testenv.add_lang_entry("PO", "bogus-posix", "");
+
+    for lang in ["C.UTF-8", "POSIX.UTF-8"] {
+        testenv
+            .command()
+            .env("LANG", lang)
+            .arg("--list")
+            .assert()
+            .success()
+            .stdout(eq("in-english\n"));
+    }
+}
+
 #[cfg_attr(feature = "ignore-online-tests", ignore = "online test")]
 #[test]
 fn test_update_language_arg() {


### PR DESCRIPTION
## What's broken

`C` and `POSIX` are only ignored when they carry no encoding suffix, so `LANG=C.UTF-8` (the default on many distros and in most containers) is truncated to its first two characters and tealdeer looks for a `pages.C.` directory instead of falling back to English. `POSIX.UTF-8` becomes `pages.PO`.

The tldr CLIENT-SPECIFICATION says `LANG` has the form `ll[_CC][.encoding]` and that both variables "may contain the values `C` or `POSIX`, which should be ignored".

## Repro

Cache with `foo` under `pages.en` and `bogus` under `pages.C.`:

```
before:
  LANG=C.UTF-8      -> list: bogus foo
  LANG=POSIX.UTF-8  -> list: foo po
after:
  LANG=C.UTF-8      -> list: foo
  LANG=POSIX.UTF-8  -> list: foo
```

## The fix

Strip the encoding suffix before the `C`/`POSIX` check, which the spec's own format implies.

## Verification

A unit test on `get_languages` and an integration test on the built binary. Removing the strip fails both: the unit test yields `Language("C.")`, and the integration test lists `bogus-c` again.

I compared old against new over realistic locale strings rather than reading the diff: `en`, `de_DE`, `en_US.UTF-8`, `fr_FR.ISO8859-1`, `zh_CN.GB2312`, `ja_JP.eucJP`, `en_GB@euro`, the empty string, and bare `C` and `POSIX` all produce identical results. Only `C.UTF-8` and `POSIX.UTF-8` change, and only from a bogus value to nothing.

`cargo test --release` passes, 32 and 55. `cargo fmt --check` clean. `cargo clippy` reports only the pre-existing `default_trait_access` at `src/config.rs:808`, which I did not touch.

*Per the AI policy: written with AI assistance (Claude Code). I ran the binary for both locales, ran the mutation checks, and did the old-versus-new comparison myself.*
