### PR TITLE
Note orphaned patches when the corresponding page is missing

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -92,9 +92,18 @@ impl<'a> Cache<'a> {
             .context("Error comparing cache mtime with current time")
     }
 
+    /// Look up the patch file (`<command>.patch.md`) for `command` in the
+    /// custom pages directory, returning its path if such a file exists.
+    pub fn find_patch(&self, command: &str) -> Option<PathBuf> {
+        let patch_filename = format!("{command}.patch.md");
+        self.config
+            .custom_pages_directory
+            .map(|dir| dir.join(&patch_filename))
+            .filter(|path| path.is_file())
+    }
+
     pub fn find_page(&self, command: &str) -> Option<PageLookupResult> {
         let page_filename = format!("{command}.md");
-        let patch_filename = format!("{command}.patch.md");
         let custom_filename = format!("{command}.page.md");
 
         if let Some(custom_pages_dir) = self.config.custom_pages_directory {
@@ -104,11 +113,7 @@ impl<'a> Cache<'a> {
             }
         }
 
-        let patch_path = self
-            .config
-            .custom_pages_directory
-            .map(|dir| dir.join(&patch_filename))
-            .filter(|path| path.is_file());
+        let patch_path = self.find_patch(command);
 
         for &platform in self.config.platforms {
             for language in self.config.search_languages {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ compile_error!(
 
 use std::{
     env,
+    fmt::Write as _,
     fs::create_dir_all,
     io::{self, IsTerminal},
     path::Path,
@@ -419,14 +420,20 @@ fn try_main(args: Cli, enable_styles: bool) -> Result<ExitCode> {
 
         let Some(result) = cache.find_page(&command) else {
             if !args.quiet {
-                print_warning(
-                    enable_styles,
-                    &format!(
-                        "Page `{command}` not found in cache.\n\
-                         Try updating with `tldr --update`, or submit a pull request to:\n\
-                         https://github.com/tldr-pages/tldr"
-                    ),
+                let mut message = format!(
+                    "Page `{command}` not found in cache.\n\
+                     Try updating with `tldr --update`, or submit a pull request to:\n\
+                     https://github.com/tldr-pages/tldr"
                 );
+                if let Some(patch_path) = cache.find_patch(&command) {
+                    let _ = write!(
+                        message,
+                        "\n\nNote: a patch for `{command}` exists at {}, \
+                         but there is no page for it to apply to.",
+                        patch_path.display(),
+                    );
+                }
+                print_warning(enable_styles, &message);
             }
             return Ok(ExitCode::FAILURE);
         };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1024,6 +1024,40 @@ fn test_multiple_platform_command_search_not_found() {
 }
 
 #[test]
+fn test_orphaned_patch_note() {
+    let testenv = TestEnv::new().write_custom_pages_config();
+
+    // Populate the cache so the lookup reaches the page-not-found path.
+    testenv.add_entry("foo", "");
+
+    // A patch with no corresponding page (an orphaned patch).
+    testenv.add_patch_entry("bar", "");
+
+    testenv
+        .command()
+        .args(["bar"])
+        .assert()
+        .failure()
+        .stderr(contains("Page `bar` not found in cache."))
+        .stderr(contains("a patch for `bar` exists"));
+}
+
+#[test]
+fn test_not_found_without_patch_has_no_note() {
+    let testenv = TestEnv::new().write_custom_pages_config();
+
+    testenv.add_entry("foo", "");
+
+    testenv
+        .command()
+        .args(["bar"])
+        .assert()
+        .failure()
+        .stderr(contains("Page `bar` not found in cache."))
+        .stderr(contains("a patch for").not());
+}
+
+#[test]
 fn test_macos_is_alias_for_osx() {
     let testenv = TestEnv::new();
     testenv.add_os_entry("osx", "maconly", "this command only exists on mac");


### PR DESCRIPTION
Closes #385 by mentioning an orphaned patch in the "page not found" message, so a user whose patch has lost its page finds out instead of the patch being silently ignored.

Patches (`<command>.patch.md`) are only ever appended to a matching page; if the page is later renamed or removed upstream, `tldr <command>` just prints the generic "not found" message and the patch quietly does nothing. In the linked issue @niklasmohrin suggested including a note about the existence of a patch in that message, which is what this does.

The patch-lookup logic that already lived inside `find_page` is pulled out into a small `Cache::find_patch` method, and the not-found branch in `main` now calls it: if a patch exists for the command, the warning gains a line pointing at the patch path and noting there is no page for it to apply to. Default output is unchanged when no orphaned patch is present, and nothing is printed under `--quiet`.

### Testing

Added two integration tests in `tests/lib.rs`: one asserting the note appears (with the command name) when an orphaned patch exists, and one asserting no such note is added for an ordinary missing page. `cargo test` passes (31 unit + 56 integration), `cargo fmt --check` is clean, and `cargo clippy --all-targets --features logging` introduces no new warnings. Also verified by hand against a scratch cache/custom-pages dir.
